### PR TITLE
Change partition layout from 25%-25%-50% to 40%-40%-20%

### DIFF
--- a/meta-topic-platform/recipes-support/swupdate/swupdate/partition_sd_card.sh
+++ b/meta-topic-platform/recipes-support/swupdate/swupdate/partition_sd_card.sh
@@ -53,9 +53,9 @@ echo ""
 parted --align optimal --script ${DEV} -- \
 	mklabel msdos \
 	mkpart primary fat16 1MiB 64MiB \
-	mkpart primary ext4 64MiB 25% \
-	mkpart primary ext4 25% 50% \
-	mkpart primary ext4 50% -1s \
+	mkpart primary ext4 64MiB 40% \
+	mkpart primary ext4 40% 80% \
+	mkpart primary ext4 80% -1s \
 	set 2 boot on
 
 # Wait until kernel reloaded partition table

--- a/meta-topic-platform/recipes-topic/expand-wic-partition/expand-wic-partition/expand-wic-partition.sh
+++ b/meta-topic-platform/recipes-topic/expand-wic-partition/expand-wic-partition/expand-wic-partition.sh
@@ -12,9 +12,9 @@ then
 	touch /dev/nomount.${DEV_BASE}
 
 	parted --align optimal --script ${BLOCK_DEV} -- \
-		resizepart 2 25% \
-		mkpart primary ext4 25% 50% \
-		mkpart primary ext4 50% -1s
+		resizepart 2 40% \
+		mkpart primary ext4 40% 80% \
+		mkpart primary ext4 80% -1s
 
 	# Wait until kernel reloaded partition table
 	# The system is removing & adding the devices several times, therefore sleep for 2 seconds


### PR DESCRIPTION
After installing QtCreator and firefox, the desktop image grows to 1.9GB. With an 8GB
storage card, the rootfs would be 25% of 8GB equals 2GB. To make room for more, change
the default partitioning to make more space available in the rootfs at the expense of
the data partition that hitherto isn't used much anyway.