### PR TITLE
my-image: add kernel-image explicitly to my-image

### DIFF
--- a/meta-topic-platform/recipes-core/images/my-image.bb
+++ b/meta-topic-platform/recipes-core/images/my-image.bb
@@ -18,6 +18,7 @@ require ${@bb.utils.contains("IMAGE_FEATURES", "swupdate", "swu.inc", "", d)}
 
 MY_THINGS = "\
 	kernel-devicetree \
+	kernel-image \
 	${@bb.utils.contains('VIRTUAL-RUNTIME_dev_manager', 'busybox-mdev', 'modutils-loadscript', '', d)} \
 	${@ 'mtd-utils-ubifs' if d.getVar('UBI_SUPPORT') == 'true' else ''} \
 	${@ 'expand-wic-partition' if d.getVar('WIC_SUPPORT') == 'true' else ''} \


### PR DESCRIPTION
my-image was missing the dependency to kernel-image. This dependency usually
gets added implicitly through a kernel-module. The new tdpzu9 target is not
loading any kernel-modules at the moment and therefore it was missing the
entire kernel.