### PR TITLE
scripts/install_to_sd_common.sh: Make partition 2 bootable by default

### DIFF
--- a/scripts/install_to_sd_common.sh
+++ b/scripts/install_to_sd_common.sh
@@ -68,8 +68,9 @@ then
 	then
 		ROOTFS=${MEDIA}/sd-rootfs-b
 	else
-		echo "Unsupported bootable partition"
-		exit 1
+		echo "Setting sd-rootfs-a as bootable partition"
+		parted ${BLOCK_DEV} set 2 boot on
+		ROOTFS=${MEDIA}/sd-rootfs-a
 	fi
 
 	if [ -z "${IMAGE}" ]


### PR DESCRIPTION
On "unknown" boot partition, make partition 2 bootable so that the script
succeeds on cards that have no bootable partition or made partition 1
bootable instead.